### PR TITLE
Bumping up constraintlayout version to fix a build issue in Andoid st…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha4'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
     implementation 'com.jakewharton.timber:timber:4.7.1'
 }


### PR DESCRIPTION
…udio 3.6 RC1

I was going through the Udemy course of Android app dev and I was getting an error after importing this project into Android Studio 3.6 RC1. Updating the constraint layout version fixed it.
<img width="989" alt="Screenshot 2020-01-04 at 8 08 34 PM" src="https://user-images.githubusercontent.com/3799600/71767131-e712ee00-2f2e-11ea-92c6-e8b22915f7b9.png">
