### PR TITLE
Update deprecated Handler constructor

### DIFF
--- a/app/src/main/java/com/example/android/dessertpusher/DessertTimer.kt
+++ b/app/src/main/java/com/example/android/dessertpusher/DessertTimer.kt
@@ -17,6 +17,7 @@
 package com.example.android.dessertpusher
 
 import android.os.Handler
+import android.os.Looper
 import timber.log.Timber
 
 /**
@@ -43,7 +44,7 @@ class DessertTimer {
      * [Handler] is a class meant to process a queue of messages (known as [android.os.Message]s)
      * or actions (known as [Runnable]s)
      */
-    private var handler = Handler()
+    private var handler = Handler(Looper.getMainLooper())
     private lateinit var runnable: Runnable
 
 


### PR DESCRIPTION
'constructor Handler()' is deprecated. Deprecated in Java

Creating an object of Handler using the new Handler() is deprecated.
As per the documentation, using a new Handler() can lead to bugs. So you should specify a looper for the handler explicitly. Looper must not be null.