### PR TITLE
Lifecycle OnLifecycleEvent is deprecated

### DIFF
--- a/app/src/main/java/com/example/android/dessertpusher/DessertTimer.kt
+++ b/app/src/main/java/com/example/android/dessertpusher/DessertTimer.kt
@@ -17,9 +17,7 @@
 package com.example.android.dessertpusher
 
 import android.os.Handler
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.*
 import timber.log.Timber
 
 /**
@@ -37,8 +35,7 @@ import timber.log.Timber
  * https://developer.android.com/guide/components/processes-and-threads
  *
  */
-class DessertTimer(lifecycle: Lifecycle) : LifecycleObserver {
-
+class DessertTimer: DefaultLifecycleObserver {
     // The number of seconds counted since the timer started
     var secondsCount = 0
 
@@ -48,15 +45,8 @@ class DessertTimer(lifecycle: Lifecycle) : LifecycleObserver {
      */
     private var handler = Handler()
     private lateinit var runnable: Runnable
+    
 
-
-    init {
-        // Add this as a lifecycle Observer, which allows for the class to react to changes in this
-        // activity's lifecycle state
-        lifecycle.addObserver(this)
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun startTimer() {
         // Create the runnable action, which prints out a log and increments the seconds counter
         runnable = Runnable {
@@ -75,10 +65,19 @@ class DessertTimer(lifecycle: Lifecycle) : LifecycleObserver {
         // In this case, no looper is defined, and it defaults to the main or UI thread.
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun stopTimer() {
         // Removes all pending posts of runnable from the handler's queue, effectively stopping the
         // timer
         handler.removeCallbacks(runnable)
+    }
+    
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        startTimer()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        stopTimer()
     }
 }


### PR DESCRIPTION
It's deprecated because they now expect you to use Java 8 and implement the interface DefaultLifecycleObserver. Since Java 8 allows interfaces to have default implementations, they defined DefaultLifecycleObserver with empty implementations of all the methods so you only need to override the ones you use.

The old way of marking functions with @OnLifecycleEvent was a crutch for pre-Java 8 projects. This was the only way to allow a class to selectively choose which lifecycle events it cared about. The alternative would have been to force those classes to override all the lifecycle interface methods, even if leaving them empty.